### PR TITLE
boost docker python image to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # For more information, please refer to https://aka.ms/vscode-docker-python
-FROM python:3.7-slim-buster
+FROM python:3.9-slim-buster
 
 # Install pip requirements
 COPY requirements.txt .


### PR DESCRIPTION
pickle load not working on heroku due to py version conflict